### PR TITLE
Checks post to see if bot has commented already

### DIFF
--- a/accounts.json
+++ b/accounts.json
@@ -1,8 +1,9 @@
 [{
-    "username": "USERNAME_1",
-    "password": "PASSWORD_1"
-},
-{
-    "username": "USERNAME_2",
-    "password": "PASSWORD_2"
-}]
+        "username": "USERNAME_1",
+        "password": "PASSWORD_1"
+    },
+    {
+        "username": "USERNAME_2",
+        "password": "PASSWORD_2"
+    }
+]

--- a/bot.py
+++ b/bot.py
@@ -4,35 +4,54 @@ import json
 import requests
 import os
 import time
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+
 
 load_dotenv(find_dotenv())
 
-clients = [];
-feed = [];
+clients = []
+feed = []
+usernames = []
+
+contains_comment = False
 
 with open('./accounts.json') as f:
     data = json.load(f)
     for acc in data:
+        usernames.append(acc['username'])
         print('Logging in with username %s' % acc['username'])
         client = Client(acc['username'], acc['password'])
         clients.append(client)
         feed = client.feed_tag('blacklivesmatter', client.generate_uuid())
 
+
 while len(feed) != 0:
     for client in clients:
-        post = feed['items'].pop(0);
+        post = feed['items'].pop(0)
         if 'image_versions2' in post:
             try:
                 url = post['image_versions2']['candidates'][0]['url']
-                res = requests.post(os.getenv("CLOUD_FUNCTION_URL"), data = { 'img_url': url })
+                res = requests.post(
+                    os.getenv("CLOUD_FUNCTION_URL"), data={'img_url': url})
                 json_res = res.json()
                 if(json_res['solid']):
                     code = post['code']
-                    print('Solid image found. Informing user on post %s' % code)
-                    client.post_comment(post['id'], 'Hi, please dont use the blacklivesmatter tag as it is currently blocking important info from being shared. Please delete and repost with #BlackoutTuesday instead (Editing the caption wont work). If you want other ways to help please check out our bio. Thank you :)')
+                    if 'comment_count' in post and post['comment_count'] > 0:
+                        for comment in post['preview_comments']:
+                            if "please dont use the blacklivesmatter tag" in comment['text'].lower():
+                                contains_comment = True
+                                break
+                        if not contains_comment:
+                            print(
+                                'Solid image found. Informing user on post %s' % code)
+                            client.post_comment(
+                                post['id'], 'Hi, please dont use the blacklivesmatter tag as it is currently blocking important info from being shared. Please delete and repost with #BlackoutTuesday instead (Editing the caption wont work). If you want other ways to help please check out our bio. Thank you :)')
+                        else:
+                            print(f'Bot has already commented on post: {code}')
+                        contains_comment = False
             except:
-                print('Ran into an exception (IG may be rate limiting)');
+                print('Ran into an exception (IG may be rate limiting)')
                 continue
         if len(feed) == 1:
             feed = client.feed_tag('blacklivesmatter', client.generate_uuid())
-                    

--- a/bot.py
+++ b/bot.py
@@ -12,14 +12,12 @@ load_dotenv(find_dotenv())
 
 clients = []
 feed = []
-usernames = []
 
 contains_comment = False
 
 with open('./accounts.json') as f:
     data = json.load(f)
     for acc in data:
-        usernames.append(acc['username'])
         print('Logging in with username %s' % acc['username'])
         client = Client(acc['username'], acc['password'])
         clients.append(client)

--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,8 @@ feed = []
 
 contains_comment = False
 
+MESSAGE = "'Hi, please dont use the blacklivesmatter tag as it is currently blocking important info from being shared. Please delete and repost with #BlackoutTuesday instead (Editing the caption wont work). If you want other ways to help please check out our bio. Thank you :)'"
+
 with open('./accounts.json') as f:
     data = json.load(f)
     for acc in data:
@@ -44,10 +46,15 @@ while len(feed) != 0:
                             print(
                                 'Solid image found. Informing user on post %s' % code)
                             client.post_comment(
-                                post['id'], 'Hi, please dont use the blacklivesmatter tag as it is currently blocking important info from being shared. Please delete and repost with #BlackoutTuesday instead (Editing the caption wont work). If you want other ways to help please check out our bio. Thank you :)')
+                                post['id'], MESSAGE)
                         else:
                             print(f'Bot has already commented on post: {code}')
                         contains_comment = False
+                    else:
+                        print(
+                            'Solid image found. Informing user on post %s' % code)
+                        client.post_comment(
+                            post['id'], MESSAGE)
             except:
                 print('Ran into an exception (IG may be rate limiting)')
                 continue


### PR DESCRIPTION
You can most likely make this better by caching, but I think this solution would work for the time being. If the bot is ready to comment on a post, it first iterates through the post's comments (if any) and checks if a bot has already commented on it with the message. I decided that instead of checking by User ID (since there may be multiple people / accounts running this bot), I check if a portion of relevant text is in the comment. If it is, no need to re-comment. If not, the bot knows to go ahead and comment. Overall, this feature will prevent bots spamming a user's post telling them to repost with the new hashtag! One comment is enough :D