### PR TITLE
Suggestion for implementation of self rate limiting.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,8 +11,7 @@ load_dotenv(find_dotenv())
 
 clients = [];
 feed = [];
-num_accounts = 0;
-ops_per_minute = 0;
+rate_limiter = RateLimiter(max_calls=200, period=60.0);
 
 with open('./accounts.json') as f:
     data = json.load(f)
@@ -24,8 +23,6 @@ with open('./accounts.json') as f:
         client = Client(acc['username'], acc['password'])
         clients.append(client)
         feed = client.feed_tag('blacklivesmatter', client.generate_uuid())
-
-rate_limiter = RateLimiter(max_calls=ops_per_minute, period=60.0)
 
 while len(feed) != 0:
     for client in clients:

--- a/bot.py
+++ b/bot.py
@@ -15,9 +15,6 @@ rate_limiter = RateLimiter(max_calls=200, period=60.0);
 
 with open('./accounts.json') as f:
     data = json.load(f)
-    num_accounts = len(data)
-    # https://developers.facebook.com/docs/graph-api/overview/rate-limiting#instagram
-    ops_per_minute = 200 * num_accounts
     for acc in data:
         print('Logging in with username %s' % acc['username'])
         client = Client(acc['username'], acc['password'])

--- a/bot.py
+++ b/bot.py
@@ -5,34 +5,44 @@ import requests
 import os
 import time
 
+from ratelimiter import RateLimiter
+
 load_dotenv(find_dotenv())
 
 clients = [];
 feed = [];
+num_accounts = 0;
+ops_per_minute = 0;
 
 with open('./accounts.json') as f:
     data = json.load(f)
+    num_accounts = len(data)
+    # https://developers.facebook.com/docs/graph-api/overview/rate-limiting#instagram
+    ops_per_minute = 200 * num_accounts
     for acc in data:
         print('Logging in with username %s' % acc['username'])
         client = Client(acc['username'], acc['password'])
         clients.append(client)
         feed = client.feed_tag('blacklivesmatter', client.generate_uuid())
 
+rate_limiter = RateLimiter(max_calls=ops_per_minute, period=60.0)
+
 while len(feed) != 0:
     for client in clients:
-        post = feed['items'].pop(0);
-        if 'image_versions2' in post:
-            try:
-                url = post['image_versions2']['candidates'][0]['url']
-                res = requests.post(os.getenv("CLOUD_FUNCTION_URL"), data = { 'img_url': url })
-                json_res = res.json()
-                if(json_res['solid']):
-                    code = post['code']
-                    print('Solid image found. Informing user on post %s' % code)
-                    client.post_comment(post['id'], 'Hi, please dont use the blacklivesmatter tag as it is currently blocking important info from being shared. Please delete and repost with #BlackoutTuesday instead (Editing the caption wont work). If you want other ways to help please check out our bio. Thank you :)')
-            except:
-                print('Ran into an exception (IG may be rate limiting)');
-                continue
-        if len(feed) == 1:
-            feed = client.feed_tag('blacklivesmatter', client.generate_uuid())
-                    
+        with rate_limiter:
+            post = feed['items'].pop(0);
+            if 'image_versions2' in post:
+                try:
+                    url = post['image_versions2']['candidates'][0]['url']
+                    res = requests.post(os.getenv("CLOUD_FUNCTION_URL"), data = { 'img_url': url })
+                    json_res = res.json()
+                    if(json_res['solid']):
+                        code = post['code']
+                        print('Solid image found. Informing user on post %s' % code)
+                        client.post_comment(post['id'], 'Hi, please dont use the blacklivesmatter tag as it is currently blocking important info from being shared. Please delete and repost with #BlackoutTuesday instead (Editing the caption wont work). If you want other ways to help please check out our bio. Thank you :)')
+                except:
+                    print('Ran into an exception (IG may be rate limiting)');
+                    continue
+            if len(feed) == 1:
+                feed = client.feed_tag('blacklivesmatter', client.generate_uuid())
+                        

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pywin32==227
 requests==2.23.0
 typing==3.7.4.1
 urllib3==1.25.9
+ratelimiter==1.2.0.post0


### PR DESCRIPTION
Hi! I have a suggestion for how to approach the IG API rate limiting issue:

Since the rate limit is 200 ops/account/minute, you can create a rate limiter (using [this](https://pypi.org/project/ratelimiter/) package) with 200 ops/min/client. That way, you don't need to keep making multiple accounts.

I haven't really tested this as I didn't have time to replicate/set anything up locally, so the actual implementation might be slightly different, but this could be the general idea :)