### PR TITLE
Fix requirements.txt for non windows users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 COPY . /usr/local/share
 WORKDIR /usr/local/share
-RUN pip install --no-cache-dir -r requirements_docker.txt
+RUN pip install --no-cache-dir -r requirements.txt
 ENV CLOUD_FUNCTION_URL=https://us-central1-protect-blm.cloudfunctions.net/isSolidColor
 CMD ["python", "bot.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9
 instagram-private-api==1.6.0
-pypiwin32==223
+pypiwin32==223;platform_system == "Windows"
 python-dotenv==0.13.0
-pywin32==227
+pywin32==227;platform_system == "Windows"
 requests==2.23.0
 typing==3.7.4.1
 urllib3==1.25.9

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,9 +1,0 @@
-certifi==2020.4.5.1
-chardet==3.0.4
-idna==2.9
-instagram-private-api==1.6.0
-python-dotenv==0.13.0
-requests==2.23.0
-typing==3.7.4.1
-urllib3==1.25.9
-ratelimiter==1.2.0.post0


### PR DESCRIPTION
This will skip the windows dependencies for mac and linux users, had some trouble with it, hopefully it will help someone! Found the solution at https://stackoverflow.com/questions/16011379/operating-system-specific-requirements-with-pip